### PR TITLE
FIX: Disable quad precision on systems that don't support it

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: fa36c0716ab0526cb98693094b7efa2219434bed9f59429f123b654a33309848
 
 build:
-  number: 2
+  number: 3
 
 outputs:
   - name: {{ name }}
@@ -24,6 +24,10 @@ outputs:
       script:
         - sed -i "s|FC = gfortran|FC = $FC|g" Config
         - sed -i "s|FFLAGS = -O|FFLAGS = $FFLAGS|g" Config
+        # Disable quad precision on systems that don't support libquadmath
+        # (linux-aarch64, osx)
+        - sed -i "/QPKIND/d" Config  # [linux-aarch64 or osx]
+        - cat Config
         # Get .dylib extension for macOS
         - sed -i "s|libavh_olo.so|libavh_olo${SHLIB_EXT}|g" create.py  # [osx]
         # FIXME: Link in libgfortran for arm64 macOS
@@ -103,6 +107,10 @@ outputs:
       script:
         - sed -i "s|FC = gfortran|FC = $FC|g" Config
         - sed -i "s|FFLAGS = -O|FFLAGS = $FFLAGS|g" Config
+        # Disable quad precision on systems that don't support libquadmath
+        # (linux-aarch64, osx)
+        - sed -i "/QPKIND/d" Config  # [linux-aarch64 or osx]
+        - cat Config
         - python create.py
         - mkdir -p $PREFIX/include/oneloop
         - mv *.mod $PREFIX/include/oneloop/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -188,6 +188,8 @@ about:
     internal squared masses. It deals with all UV and IR divergences within
     dimensional regularization. Furthermore, it provides routines to evaluate
     these functions using straightforward numerical integration.
+
+    OneLOop is authored by Andreas van Hameren.
   license: GPL-3.0-only
   license_family: GPL
   license_file: COPYING

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -69,8 +69,24 @@ outputs:
         - test -f $PREFIX/include/oneloop/avh_olo_dp_tri.mod
         - test -f $PREFIX/include/oneloop/avh_olo_dp_box.mod
         - test -f $PREFIX/include/oneloop/avh_olo_dp_boxc.mod
-        - test -f $PREFIX/include/oneloop/avh_olo_qp_kinds.mod
+        - test ! -f $PREFIX/include/oneloop/avh_olo_qp_kinds.mod  # [(linux and aarch64) or osx]
+        - test -f $PREFIX/include/oneloop/avh_olo_qp_kinds.mod  # [not ((linux and aarch64) or osx)]
         - test -f $PREFIX/include/oneloop/avh_olo_dp.mod
+      {% if ((linux and aarch64) or osx) %}
+        - test ! -f $PREFIX/include/oneloop/avh_olo_qp_arrays.mod
+        - test ! -f $PREFIX/include/oneloop/avh_olo_qp_prec.mod
+        - test ! -f $PREFIX/include/oneloop/avh_olo_qp_print.mod
+        - test ! -f $PREFIX/include/oneloop/avh_olo_qp_auxfun.mod
+        - test ! -f $PREFIX/include/oneloop/avh_olo_qp_olog.mod
+        - test ! -f $PREFIX/include/oneloop/avh_olo_qp_dilog.mod
+        - test ! -f $PREFIX/include/oneloop/avh_olo_qp_bnlog.mod
+        - test ! -f $PREFIX/include/oneloop/avh_olo_qp_qmplx.mod
+        - test ! -f $PREFIX/include/oneloop/avh_olo_qp_bub.mod
+        - test ! -f $PREFIX/include/oneloop/avh_olo_qp_tri.mod
+        - test ! -f $PREFIX/include/oneloop/avh_olo_qp_box.mod
+        - test ! -f $PREFIX/include/oneloop/avh_olo_qp_boxc.mod
+        - test ! -f $PREFIX/include/oneloop/avh_olo_qp.mod
+      {% else %}
         - test -f $PREFIX/include/oneloop/avh_olo_qp_arrays.mod
         - test -f $PREFIX/include/oneloop/avh_olo_qp_prec.mod
         - test -f $PREFIX/include/oneloop/avh_olo_qp_print.mod
@@ -84,6 +100,7 @@ outputs:
         - test -f $PREFIX/include/oneloop/avh_olo_qp_box.mod
         - test -f $PREFIX/include/oneloop/avh_olo_qp_boxc.mod
         - test -f $PREFIX/include/oneloop/avh_olo_qp.mod
+      {% endif %}
         - test -f $PREFIX/include/oneloop/avh_olo.mod
 
         - cd example
@@ -149,8 +166,24 @@ outputs:
         - test -f $PREFIX/include/oneloop/avh_olo_dp_tri.mod
         - test -f $PREFIX/include/oneloop/avh_olo_dp_box.mod
         - test -f $PREFIX/include/oneloop/avh_olo_dp_boxc.mod
-        - test -f $PREFIX/include/oneloop/avh_olo_qp_kinds.mod
+        - test ! -f $PREFIX/include/oneloop/avh_olo_qp_kinds.mod  # [(linux and aarch64) or osx]
+        - test -f $PREFIX/include/oneloop/avh_olo_qp_kinds.mod  # [not ((linux and aarch64) or osx)]
         - test -f $PREFIX/include/oneloop/avh_olo_dp.mod
+      {% if ((linux and aarch64) or osx) %}
+        - test ! -f $PREFIX/include/oneloop/avh_olo_qp_arrays.mod
+        - test ! -f $PREFIX/include/oneloop/avh_olo_qp_prec.mod
+        - test ! -f $PREFIX/include/oneloop/avh_olo_qp_print.mod
+        - test ! -f $PREFIX/include/oneloop/avh_olo_qp_auxfun.mod
+        - test ! -f $PREFIX/include/oneloop/avh_olo_qp_olog.mod
+        - test ! -f $PREFIX/include/oneloop/avh_olo_qp_dilog.mod
+        - test ! -f $PREFIX/include/oneloop/avh_olo_qp_bnlog.mod
+        - test ! -f $PREFIX/include/oneloop/avh_olo_qp_qmplx.mod
+        - test ! -f $PREFIX/include/oneloop/avh_olo_qp_bub.mod
+        - test ! -f $PREFIX/include/oneloop/avh_olo_qp_tri.mod
+        - test ! -f $PREFIX/include/oneloop/avh_olo_qp_box.mod
+        - test ! -f $PREFIX/include/oneloop/avh_olo_qp_boxc.mod
+        - test ! -f $PREFIX/include/oneloop/avh_olo_qp.mod
+      {% else %}
         - test -f $PREFIX/include/oneloop/avh_olo_qp_arrays.mod
         - test -f $PREFIX/include/oneloop/avh_olo_qp_prec.mod
         - test -f $PREFIX/include/oneloop/avh_olo_qp_print.mod
@@ -164,6 +197,7 @@ outputs:
         - test -f $PREFIX/include/oneloop/avh_olo_qp_box.mod
         - test -f $PREFIX/include/oneloop/avh_olo_qp_boxc.mod
         - test -f $PREFIX/include/oneloop/avh_olo_qp.mod
+      {% endif %}
         - test -f $PREFIX/include/oneloop/avh_olo.mod
 
         - cd example

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -107,15 +107,27 @@ outputs:
         - export WITHLT=no
         - export LTVSNge26=yes
         - export WITHCOLI=no
+
+        - ../src/avh_pc_exe.py "case" "LT" "${WITHLT}" example.f
+        - ../src/avh_pc_exe.py "case" "LTVSNge26" "${WITHLT}${LTVSNge26}" example.f
+        - ../src/avh_pc_exe.py "case" "COLI" "${WITHCOLI}" example.f
+
+      {% if not ((linux and aarch64) or osx) %}
         - ../src/avh_pc_exe.py "case" "LT" "${WITHLT}" example16.f
         - ../src/avh_pc_exe.py "case" "LTVSNge26" "${WITHLT}${LTVSNge26}" example16.f
         - ../src/avh_pc_exe.py "case" "COLI" "${WITHCOLI}" example16.f
+      {% endif %}
         - unset WITHLT
         - unset LTVSNge26
         - unset WITHCOLI
         # Use $LDFLAGS for more generic solution to -L$PREFIX/lib
-        - $FC $FFLAGS example16.f -o example -I$PREFIX/include/oneloop $LDFLAGS -lavh_olo
-        - ./example < input  # [build_platform == target_platform]
+        - $FC $FFLAGS example.f -o example -I$PREFIX/include/oneloop $LDFLAGS -lavh_olo
+        - ./example < input
+
+      {% if not ((linux and aarch64) or osx) %}
+        - $FC $FFLAGS example16.f -o example16 -I$PREFIX/include/oneloop $LDFLAGS -lavh_olo
+        - ./example16 < input
+      {% endif %}
 
   - name: {{ name }}-static
 
@@ -204,15 +216,27 @@ outputs:
         - export WITHLT=no
         - export LTVSNge26=yes
         - export WITHCOLI=no
+
+        - ../src/avh_pc_exe.py "case" "LT" "${WITHLT}" example.f
+        - ../src/avh_pc_exe.py "case" "LTVSNge26" "${WITHLT}${LTVSNge26}" example.f
+        - ../src/avh_pc_exe.py "case" "COLI" "${WITHCOLI}" example.f
+
+      {% if not ((linux and aarch64) or osx) %}
         - ../src/avh_pc_exe.py "case" "LT" "${WITHLT}" example16.f
         - ../src/avh_pc_exe.py "case" "LTVSNge26" "${WITHLT}${LTVSNge26}" example16.f
         - ../src/avh_pc_exe.py "case" "COLI" "${WITHCOLI}" example16.f
+      {% endif %}
         - unset WITHLT
         - unset LTVSNge26
         - unset WITHCOLI
         # Use $LDFLAGS for more generic solution to -L$PREFIX/lib
-        - $FC $FFLAGS example16.f -o example -I$PREFIX/include/oneloop $LDFLAGS -lavh_olo
-        - ./example < input  # [build_platform == target_platform]
+        - $FC $FFLAGS example.f -o example -I$PREFIX/include/oneloop $LDFLAGS -lavh_olo
+        - ./example < input
+
+      {% if not ((linux and aarch64) or osx) %}
+        - $FC $FFLAGS example16.f -o example16 -I$PREFIX/include/oneloop $LDFLAGS -lavh_olo
+        - ./example16 < input
+      {% endif %}
 
 about:
   home: https://bitbucket.org/hameren/oneloop/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ outputs:
         - sed -i "s|FC = gfortran|FC = $FC|g" Config
         - sed -i "s|FFLAGS = -O|FFLAGS = $FFLAGS|g" Config
         # Disable quad precision on systems that don't support libquadmath
-        - sed -i "/QPKIND/d" Config  # [linux-aarch64 or osx]
+        - sed -i "/QPKIND/d" Config  # [(linux and aarch64) or osx]
         - cat Config
         # Get .dylib extension for macOS
         - sed -i "s|libavh_olo.so|libavh_olo${SHLIB_EXT}|g" create.py  # [osx]
@@ -107,7 +107,7 @@ outputs:
         - sed -i "s|FC = gfortran|FC = $FC|g" Config
         - sed -i "s|FFLAGS = -O|FFLAGS = $FFLAGS|g" Config
         # Disable quad precision on systems that don't support libquadmath
-        - sed -i "/QPKIND/d" Config  # [linux-aarch64 or osx]
+        - sed -i "/QPKIND/d" Config  # [(linux and aarch64) or osx]
         - cat Config
         - python create.py
         - mkdir -p $PREFIX/include/oneloop

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,6 @@ outputs:
         - sed -i "s|FC = gfortran|FC = $FC|g" Config
         - sed -i "s|FFLAGS = -O|FFLAGS = $FFLAGS|g" Config
         # Disable quad precision on systems that don't support libquadmath
-        # (linux-aarch64, osx)
         - sed -i "/QPKIND/d" Config  # [linux-aarch64 or osx]
         - cat Config
         # Get .dylib extension for macOS
@@ -108,7 +107,6 @@ outputs:
         - sed -i "s|FC = gfortran|FC = $FC|g" Config
         - sed -i "s|FFLAGS = -O|FFLAGS = $FFLAGS|g" Config
         # Disable quad precision on systems that don't support libquadmath
-        # (linux-aarch64, osx)
         - sed -i "/QPKIND/d" Config  # [linux-aarch64 or osx]
         - cat Config
         - python create.py

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,7 @@ outputs:
         - sed -i "s|FFLAGS = -O|FFLAGS = $FFLAGS|g" Config
         # Disable quad precision on systems that don't support libquadmath
         - sed -i "/QPKIND/d" Config  # [(linux and aarch64) or osx]
+        - echo -e "\n# Config file"
         - cat Config
         # Get .dylib extension for macOS
         - sed -i "s|libavh_olo.so|libavh_olo${SHLIB_EXT}|g" create.py  # [osx]
@@ -108,6 +109,7 @@ outputs:
         - sed -i "s|FFLAGS = -O|FFLAGS = $FFLAGS|g" Config
         # Disable quad precision on systems that don't support libquadmath
         - sed -i "/QPKIND/d" Config  # [(linux and aarch64) or osx]
+        - echo -e "\n# Config file"
         - cat Config
         - python create.py
         - mkdir -p $PREFIX/include/oneloop


### PR DESCRIPTION
* Unset QPKIND from the Config for systems that don't support quad precision (linux-aarch64, osx).
   - Thanks to Andreas van Hameren for the fix explanation.
* Add test of example.f and only build and run example16.f on systems that support quad precision.
* Bump build number.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
